### PR TITLE
Add support for an optional port parameter.

### DIFF
--- a/src/Configuration/DatabaseConfiguration.php
+++ b/src/Configuration/DatabaseConfiguration.php
@@ -61,6 +61,23 @@ class DatabaseConfiguration extends AbstractConfiguration
     /**
      * @return string
      */
+    public function getPort()
+    {
+        return $this->get('port');
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public function setPort($value)
+    {
+        return $this->set('port', $value);
+    }
+
+    /**
+     * @return string
+     */
     public function getPassword()
     {
         return $this->get('password');

--- a/src/Configuration/SnakeConfigurationTree.php
+++ b/src/Configuration/SnakeConfigurationTree.php
@@ -38,7 +38,7 @@ class SnakeConfigurationTree implements ConfigurationInterface
                 ->children()
                     ->scalarNode('driver')->end()
                     ->scalarNode('host')->end()
-                    ->scalarNode('port')->defaultValue('3306')->end()
+                    ->scalarNode('port')->defaultValue(null)->end()
                     ->scalarNode('user')->end()
                     ->scalarNode('password')->end()
                     ->scalarNode('dbname')->end()

--- a/src/Configuration/SnakeConfigurationTree.php
+++ b/src/Configuration/SnakeConfigurationTree.php
@@ -38,6 +38,7 @@ class SnakeConfigurationTree implements ConfigurationInterface
                 ->children()
                     ->scalarNode('driver')->end()
                     ->scalarNode('host')->end()
+                    ->scalarNode('port')->defaultValue('3306')->end()
                     ->scalarNode('user')->end()
                     ->scalarNode('password')->end()
                     ->scalarNode('dbname')->end()

--- a/src/Dumper/Sql/ConnectionHandler.php
+++ b/src/Dumper/Sql/ConnectionHandler.php
@@ -113,6 +113,7 @@ class ConnectionHandler
         $connectionParams = array(
             'driver'   => $this->config->getDriver(),
             'host'     => $this->config->getHost(),
+            'port'     => $this->config->getPort(),
             'user'     => $this->config->getUser(),
             'password' => $this->config->getPassword(),
             'dbname'   => $this->config->getDatabaseName(),

--- a/src/Dumper/Sql/SqlDumperContext.php
+++ b/src/Dumper/Sql/SqlDumperContext.php
@@ -7,7 +7,6 @@ use Digilist\SnakeDumper\Converter\Service\DataConverterInterface;
 use Digilist\SnakeDumper\Converter\Service\SqlDataConverter;
 use Digilist\SnakeDumper\Dumper\Context\AbstractDumperContext;
 use Digilist\SnakeDumper\Dumper\Helper\ProgressBarHelper;
-use Digilist\SnakeDumper\Dumper\Sql\ConnectionHandler;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 


### PR DESCRIPTION
This commit adds the support of defining the sql server port in the
database configuration. If no value for port is set, the configuration
defaults to the default port 3306 (previous behavior)