### PR TITLE
add on delete/update options on foreignKeys query

### DIFF
--- a/src/Converter/Tests/ConditionalConverterTest.php
+++ b/src/Converter/Tests/ConditionalConverterTest.php
@@ -3,9 +3,9 @@
 namespace Digilist\SnakeDumper\Converter\Tests;
 
 use Digilist\SnakeDumper\Converter\ConditionalConverter;
-use Digilist\SnakeDumper\Converter\Service\DataConverter;
+use PHPUnit\Framework\TestCase;
 
-class ConditionalConverterTest extends \PHPUnit_Framework_TestCase
+class ConditionalConverterTest extends TestCase
 {
 
     public function testConditionalIfTrue()

--- a/src/Converter/Tests/RandomConverterTest.php
+++ b/src/Converter/Tests/RandomConverterTest.php
@@ -4,12 +4,13 @@ namespace Digilist\SnakeDumper\Converter\Tests;
 
 use Digilist\SnakeDumper\Converter\RandomConverter;
 use Digilist\SnakeDumper\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @package Digilist\SnakeDumper\Converter\Tests
  * @author moellers
  */
-class RandomConverterTest extends \PHPUnit_Framework_TestCase
+class RandomConverterTest extends TestCase
 {
 
     public function testEqualBounds()

--- a/src/Dumper/Sql/Dumper/StructureDumper.php
+++ b/src/Dumper/Sql/Dumper/StructureDumper.php
@@ -62,7 +62,7 @@ class StructureDumper
             foreach ($table->getForeignKeys() as $constraint) {
                 $options = '';
                 if ($onUpdate = $constraint->onUpdate()) {
-                    $options .= ' ON UPDATE' . $onUpdate;
+                    $options .= ' ON UPDATE ' . $onUpdate;
                 }
                 if ($onDelete = $constraint->onDelete()) {
                     $options .= ' ON DELETE ' . $onDelete;

--- a/src/Dumper/Sql/Dumper/StructureDumper.php
+++ b/src/Dumper/Sql/Dumper/StructureDumper.php
@@ -60,9 +60,15 @@ class StructureDumper
     public function dumpConstraints(array $tables) {
         foreach ($tables as $table) {
             foreach ($table->getForeignKeys() as $constraint) {
+                $options = '';
+                if ($onUpdate = $constraint->onUpdate()) {
+                    $options .= ' ON UPDATE' . $onUpdate;
+                }
+                if ($onDelete = $constraint->onDelete()) {
+                    $options .= ' ON DELETE ' . $onDelete;
+                }
                 $constraint = $this->platform->getCreateConstraintSQL($constraint, $table);
-
-                $this->dumpOutput->writeln($constraint . ';');
+                $this->dumpOutput->writeln($constraint . $options . ';');
             }
         }
     }

--- a/src/Dumper/Sql/Tests/AbstractSqlTest.php
+++ b/src/Dumper/Sql/Tests/AbstractSqlTest.php
@@ -2,13 +2,12 @@
 
 namespace Digilist\SnakeDumper\Dumper\Sql\Tests;
 
-use Digilist\SnakeDumper\Configuration\DatabaseConfiguration;
-use Digilist\SnakeDumper\Dumper\Sql\ConnectionHandler;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractSqlTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractSqlTest extends TestCase
 {
 
     const DBNAME = 'snakedumper';
@@ -75,7 +74,7 @@ abstract class AbstractSqlTest extends \PHPUnit_Framework_TestCase
             customer_id INTEGER,
             product VARCHAR(100),
             amount REAL,
-            CONSTRAINT customer_id FOREIGN KEY (customer_id) REFERENCES Customer(id)
+            CONSTRAINT customer_id FOREIGN KEY (customer_id) REFERENCES Customer(id) ON UPDATE CASCADE ON DELETE SET NULL
         )');
         $pdo->query('CREATE INDEX billing_product ON Billing (product)');
 

--- a/src/Dumper/Sql/Tests/TableFilterTest.php
+++ b/src/Dumper/Sql/Tests/TableFilterTest.php
@@ -6,8 +6,9 @@ use Digilist\SnakeDumper\Configuration\SqlDumperConfiguration;
 use Digilist\SnakeDumper\Configuration\Table\TableConfiguration;
 use Digilist\SnakeDumper\Dumper\Sql\TableFilter;
 use Doctrine\DBAL\Schema\Table;
+use PHPUnit\Framework\TestCase;
 
-class TableFilterTest extends \PHPUnit_Framework_TestCase
+class TableFilterTest extends TestCase
 {
 
     /**

--- a/src/Dumper/Sql/Tests/test_dump.sql
+++ b/src/Dumper/Sql/Tests/test_dump.sql
@@ -10,4 +10,4 @@ CREATE TABLE `RandomTable` (`id` INT AUTO_INCREMENT NOT NULL, `name` VARCHAR(10)
 INSERT INTO `Customer` (`id`, `name`) VALUES ('1', 'Foobar'), ('2', 'Foobar'), ('3', 'Foobar');
 INSERT INTO `Customer` (`id`, `name`) VALUES ('4', 'Foobar');
 INSERT INTO `Billing` (`id`, `customer_id`, `product`, `amount`) VALUES ('1', '1', 'IT', '42'), ('2', '1', NULL, '1337'), ('3', '2', 'Some stuff', '1337');
-ALTER TABLE `Billing` ADD CONSTRAINT `customer_id` FOREIGN KEY (`customer_id`) REFERENCES `Customer` (`id`);
+ALTER TABLE `Billing` ADD CONSTRAINT `customer_id` FOREIGN KEY (`customer_id`) REFERENCES `Customer` (`id`) ON UPDATE CASCADE ON DELETE SET NULL;


### PR DESCRIPTION
Add options `ON DELETE` && `ON UPDATE` options on foreign keys in the Dump Sql

Like 

`
ALTER TABLE 'foo' ADD CONSTRAINT 'FK_B730B620778E3E6F' FOREIGN KEY ('foo_id') REFERENCES 'bar' ('id')`  **`ON DELETE CASCADE`**;
