### PR TITLE
Require psr/log: ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "bin": ["bin/snakedumper"],
     "require": {
         "php": ">=5.5",
-        "psr/log": "~1.0.0",
+        "psr/log": "~1.0",
         "symfony/config": "~3.0",
         "symfony/yaml": "~3.0",
         "symfony/console": "~3.0",


### PR DESCRIPTION
I don't see any sense of locking to <1.1.0 since it's not major version. 
https://github.com/php-fig/log/compare/1.0.2...1.1.0 - no big changes (in fact none at all)
 
Problem 1
    - Installation request for digilist/snakedumper ^0.2.0 -> satisfiable by digilist/snakedumper[v0.2].
    - Conclusion: remove psr/log 1.1.0
    - Conclusion: don't install psr/log 1.1.0
    - digilist/snakedumper v0.2 requires psr/log ~1.0.0 -> satisfiable by psr/log[1.0.0, 1.0.1, 1.0.2].
    - Can only install one of: psr/log[1.0.0, 1.1.0].
    - Can only install one of: psr/log[1.0.1, 1.1.0].
    - Can only install one of: psr/log[1.0.2, 1.1.0].
    - Installation request for psr/log (locked at 1.1.0) -> satisfiable by psr/log[1.1.0].