### PR TITLE
Fix adding Foreign key constraint in case of disable-structure is given.

### DIFF
--- a/src/Dumper/SqlDumper.php
+++ b/src/Dumper/SqlDumper.php
@@ -40,11 +40,16 @@ class SqlDumper implements DumperInterface
         );
 
         $this->dumpPreamble($context);
+
         if (!$context->getConfig()->isIgnoreStructure()) {
             $structureDumper->dumpTableStructure($tables);
         }
+
         $this->dumpTables($context, $tables);
-        $structureDumper->dumpConstraints($tables);
+
+        if (!$context->getConfig()->isIgnoreStructure()) {
+            $structureDumper->dumpConstraints($tables);
+        }
     }
 
     /**


### PR DESCRIPTION
It could be possible that the constraints already present and the dump import will fail.